### PR TITLE
DAOS-11467 ucx: Update UCX version to 1.13.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,4 +41,4 @@
 //@Library(value="pipeline-lib@your_branch") _
 
 
-packageBuildingPipeline(['distros': ['el8', 'centos7', 'leap15', 'ubuntu20.04']])
+packageBuildingPipeline(['distros': ['el8', 'centos7', 'leap15', 'ubuntu20.04'], 'test-tag': 'daosio'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,4 +41,4 @@
 //@Library(value="pipeline-lib@your_branch") _
 
 
-packageBuildingPipeline(['distros': ['el8', 'centos7', 'leap15', 'ubuntu20.04'], 'test-tag': 'daosio'])
+packageBuildingPipelineDAOSTest(['distros': ['el8', 'centos7', 'leap15', 'ubuntu20.04'], 'test-tag': 'daosio'])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ucx (1.13.1-1) unstable; urgency=medium
+ucx (1.13.0-1) unstable; urgency=medium
 
   * Update to 1.13
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 ucx (1.13.1-1) unstable; urgency=medium
 
-  * Update to 1.13.1
+  * Update to 1.13
 
  -- Joseph Moore <joseph.moore@intel.com>  Tue, 06 Sep 2022 11:41:10 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-ucx (1.13.0-1) unstable; urgency=medium
+ucx (1.13.1-1) unstable; urgency=medium
 
-  * Update to 1.13.0
+  * Update to 1.13.1
 
- -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Wed, 29 Jun 2022 11:41:10 -0500
+ -- Joseph Moore <joseph.moore@intel.com>  Tue, 06 Sep 2022 11:41:10 -0500
 
 ucx (1.12.1-3) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ucx (1.13.0~rc1-1) unstable; urgency=medium
+
+  * Update to 1.13.0-rc1
+
+ -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Wed, 15 Jun 2022 11:41:10 -0500
+
 ucx (1.12.1-3) unstable; urgency=medium
 
   * Move undo-upstream.patch into specfile for our build system

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-ucx (1.13.0~rc1-1) unstable; urgency=medium
+ucx (1.13.0~rc2-1) unstable; urgency=medium
 
-  * Update to 1.13.0-rc1
+  * Update to 1.13.0-rc2
 
- -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Wed, 15 Jun 2022 11:41:10 -0500
+ -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Wed, 29 Jun 2022 11:41:10 -0500
 
 ucx (1.12.1-3) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-ucx (1.13.0~rc2-1) unstable; urgency=medium
+ucx (1.13.0-1) unstable; urgency=medium
 
-  * Update to 1.13.0-rc2
+  * Update to 1.13.0
 
  -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Wed, 29 Jun 2022 11:41:10 -0500
 

--- a/debian/libucx-dev.install
+++ b/debian/libucx-dev.install
@@ -4,4 +4,4 @@ usr/lib/${DEB_HOST_MULTIARCH}/lib*.so
 usr/lib/${DEB_HOST_MULTIARCH}/ucx/*.so
 usr/include/*
 /usr/share/ucx/perftest/*	/usr/share/doc/libucx-dev/perftest
-usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig/ucx.pc
+usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig/ucx*.pc

--- a/packaging/Dockerfile.ubuntu.20.04
+++ b/packaging/Dockerfile.ubuntu.20.04
@@ -17,7 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             autoconf bash ca-certificates curl debhelper dh-make        \
             dpkg-dev dh-python doxygen gcc git git-buildpackage locales \
             make patch pbuilder pkg-config python3-dev python3-distro   \
-            python3-distutils rpm scons wget
+            python3-distutils rpm scons wget cmake valgrind
 
 # rpmdevtools
 RUN echo "deb [trusted=yes] ${REPO_URL}${REPO_UBUNTU_20_04} focal main" > /etc/apt/sources.list.d/daos-stack-ubuntu-stable-local.list

--- a/ucx.spec
+++ b/ucx.spec
@@ -22,7 +22,7 @@
 %global major 1
 %global minor 13
 %global bugrelease 0
-%global prerelease rc2
+#%global prerelease rc2
 
 %global dl_version %{major}.%{minor}.%{bugrelease}
 
@@ -321,8 +321,8 @@ library internals, protocol objects, transports status, and more.
 %endif
 
 %changelog
-* Wed Jun 29 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.13.0~rc2-1
-- Update to 1.13.0-rc2
+* Wed Jun 29 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.13.0-1
+- Update to 1.13.0
 
 * Fri Jun 03 2022 Brian J. Murrell <brian.murrell@intel.com> - 1.12.1-3
 - Move debian undo-upstream.patch into specfile

--- a/ucx.spec
+++ b/ucx.spec
@@ -21,8 +21,8 @@
 
 %global major 1
 %global minor 13
-%global bugrelease 0
-#%%global prerelease rc2
+%global bugrelease 1
+#%%global prerelease rc1
 
 %global dl_version %{major}.%{minor}.%{bugrelease}
 

--- a/ucx.spec
+++ b/ucx.spec
@@ -22,7 +22,7 @@
 %global major 1
 %global minor 13
 %global bugrelease 0
-#%global prerelease rc2
+# %global prerelease rc2
 
 %global dl_version %{major}.%{minor}.%{bugrelease}
 

--- a/ucx.spec
+++ b/ucx.spec
@@ -151,7 +151,7 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.a
 %files devel
 %{_includedir}/uc*
 %{_libdir}/lib*.so
-%{_libdir}/pkgconfig/ucx.pc
+%{_libdir}/pkgconfig/ucx*.pc
 %{_libdir}/cmake/ucx/*.cmake
 %{_datadir}/ucx/examples
 

--- a/ucx.spec
+++ b/ucx.spec
@@ -120,18 +120,18 @@ Provides header files and examples for developing with UCX.
            --disable-params-check \
            --without-java \
            --without-go \
-          %_enable_arg cma cma \
-          %_with_arg cuda cuda \
-          %_with_arg gdrcopy gdrcopy \
-          %_with_arg ib verbs \
-          %_with_arg ib_cm cm \
-          %_with_arg knem knem \
-          %_with_arg rdmacm rdmacm \
-          %_with_arg rocm rocm \
-          %_with_arg xpmem xpmem \
+           %_enable_arg cma cma \
+           %_with_arg cuda cuda \
+           %_with_arg gdrcopy gdrcopy \
+           %_with_arg ib verbs \
+           %_with_arg ib_cm cm \
+           %_with_arg knem knem \
+           %_with_arg rdmacm rdmacm \
+           %_with_arg rocm rocm \
+           %_with_arg xpmem xpmem \
            %_with_arg vfs fuse3 \
-          %_with_arg ugni ugni \
-          %{?configure_options}
+           %_with_arg ugni ugni \
+           %{?configure_options}
 make %{?_smp_mflags} V=1
 
 %install

--- a/ucx.spec
+++ b/ucx.spec
@@ -98,6 +98,12 @@ The acronym UCX stands for "Unified Communication X".
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Summary: Header files required for developing with UCX
 
+%if (0%{?suse_version} > 0)
+Provides: libucs-devel = %{version}-%{release}
+Provides: libuct-devel = %{version}-%{release}
+Provides: libucp-devel = %{version}-%{release}
+%endif
+
 %description devel
 Provides header files and examples for developing with UCX.
 

--- a/ucx.spec
+++ b/ucx.spec
@@ -322,7 +322,7 @@ library internals, protocol objects, transports status, and more.
 
 %changelog
 * Tue Sep 06 2022 Joseph Moore <joseph.moore@intel.com> - 1.13.1-1
-- Update to 1.13.1
+- Update to 1.13
 
 * Fri Jun 03 2022 Brian J. Murrell <brian.murrell@intel.com> - 1.12.1-3
 - Move debian undo-upstream.patch into specfile

--- a/ucx.spec
+++ b/ucx.spec
@@ -33,7 +33,7 @@ Summary: UCX is a communication library implementing high-performance messaging
 
 License: BSD
 URL: http://www.openucx.org
-Source: https://github.com/openucx/ucx/releases/download/v%{dl_version}%{?prelease:-%{prerelease}}/ucx-%{dl_version}.tar.gz
+Source: https://github.com/openucx/ucx/releases/download/v%{dl_version}%{?prerelease:-%{prerelease}}/ucx-%{dl_version}.tar.gz
 Patch0: undo-upstream.patch
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)

--- a/ucx.spec
+++ b/ucx.spec
@@ -21,7 +21,7 @@
 
 %global major 1
 %global minor 13
-%global bugrelease
+%global bugrelease 0
 #%%global prerelease
 
 %global dl_version %{major}.%{minor}.%{bugrelease}
@@ -113,19 +113,19 @@ Provides header files and examples for developing with UCX.
            --disable-assertions \
            --disable-params-check \
            --without-java \
-	   --without-go \
-           %_enable_arg cma cma \
-           %_with_arg cuda cuda \
-           %_with_arg gdrcopy gdrcopy \
-           %_with_arg ib verbs \
-           %_with_arg ib_cm cm \
-           %_with_arg knem knem \
-           %_with_arg rdmacm rdmacm \
-           %_with_arg rocm rocm \
-           %_with_arg xpmem xpmem \
+           --without-go \
+          %_enable_arg cma cma \
+          %_with_arg cuda cuda \
+          %_with_arg gdrcopy gdrcopy \
+          %_with_arg ib verbs \
+          %_with_arg ib_cm cm \
+          %_with_arg knem knem \
+          %_with_arg rdmacm rdmacm \
+          %_with_arg rocm rocm \
+          %_with_arg xpmem xpmem \
            %_with_arg vfs fuse3 \
-           %_with_arg ugni ugni \
-           %{?configure_options}
+          %_with_arg ugni ugni \
+          %{?configure_options}
 make %{?_smp_mflags} V=1
 
 %install

--- a/ucx.spec
+++ b/ucx.spec
@@ -22,7 +22,7 @@
 %global major 1
 %global minor 13
 %global bugrelease 0
-# %global prerelease rc2
+#%%global prerelease rc2
 
 %global dl_version %{major}.%{minor}.%{bugrelease}
 

--- a/ucx.spec
+++ b/ucx.spec
@@ -102,7 +102,7 @@ Summary: Header files required for developing with UCX
 Provides header files and examples for developing with UCX.
 
 %prep
-%autosetup -p1
+%autosetup -p1 -n ucx-%{major}.%{minor}.%{bugrelease}
 
 %build
 %define _with_arg()   %{expand:%%{?with_%{1}:--with-%{2}}%%{!?with_%{1}:--without-%{2}}}

--- a/ucx.spec
+++ b/ucx.spec
@@ -19,14 +19,21 @@
 %bcond_with    xpmem
 %bcond_with    vfs
 
+%global major 1
+%global minor 13
+%global bugrelease 0
+%global prerelease rc1
+
+%global dl_version %{major}.%{minor}.%{bugrelease}
+
 Name: ucx
-Version: 1.12.1
-Release: 3%{?dist}
+Version: %{major}.%{minor}.%{bugrelease}%{?prerelease:~%{prerelease}}
+Release: 1%{?dist}
 Summary: UCX is a communication library implementing high-performance messaging
 
 License: BSD
 URL: http://www.openucx.org
-Source: https://github.com/openucx/ucx/releases/download/v%version/ucx-%version.tar.gz
+Source: https://github.com/openucx/ucx/releases/download/v%{dl_version}%{?prelease:-%{prerelease}}/ucx-%{dl_version}.tar.gz
 Patch0: undo-upstream.patch
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -314,6 +321,9 @@ library internals, protocol objects, transports status, and more.
 %endif
 
 %changelog
+* Wed Jun 15 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.13.0~rc1-1
+- Update to 1.13.0-rc1
+
 * Fri Jun 03 2022 Brian J. Murrell <brian.murrell@intel.com> - 1.12.1-3
 - Move debian undo-upstream.patch into specfile
 

--- a/ucx.spec
+++ b/ucx.spec
@@ -321,8 +321,8 @@ library internals, protocol objects, transports status, and more.
 %endif
 
 %changelog
-* Wed Jun 29 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.13.0-1
-- Update to 1.13.0
+* Tue Sep 06 2022 Joseph Moore <joseph.moore@intel.com> - 1.13.1-1
+- Update to 1.13.1
 
 * Fri Jun 03 2022 Brian J. Murrell <brian.murrell@intel.com> - 1.12.1-3
 - Move debian undo-upstream.patch into specfile

--- a/ucx.spec
+++ b/ucx.spec
@@ -22,7 +22,7 @@
 %global major 1
 %global minor 13
 %global bugrelease 0
-%global prerelease rc1
+%global prerelease rc2
 
 %global dl_version %{major}.%{minor}.%{bugrelease}
 
@@ -321,8 +321,8 @@ library internals, protocol objects, transports status, and more.
 %endif
 
 %changelog
-* Wed Jun 15 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.13.0~rc1-1
-- Update to 1.13.0-rc1
+* Wed Jun 29 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.13.0~rc2-1
+- Update to 1.13.0-rc2
 
 * Fri Jun 03 2022 Brian J. Murrell <brian.murrell@intel.com> - 1.12.1-3
 - Move debian undo-upstream.patch into specfile

--- a/ucx.spec
+++ b/ucx.spec
@@ -21,8 +21,8 @@
 
 %global major 1
 %global minor 13
-%global bugrelease 1
-#%%global prerelease rc1
+%global bugrelease
+#%%global prerelease
 
 %global dl_version %{major}.%{minor}.%{bugrelease}
 


### PR DESCRIPTION
An update to UCX 1.13 is required to enable needed changes in the Mercury UCX adapter.